### PR TITLE
miscellaneous updates: debugging and getting ready for DR8 imaging

### DIFF
--- a/bin/legacyhalos-mpi
+++ b/bin/legacyhalos-mpi
@@ -125,7 +125,7 @@ def _call_pipeline_coadds(onegal, galaxy, radius_mosaic, survey, pixscale,
         _start(galaxy)
         err = legacyhalos.coadds.pipeline_coadds(onegal, galaxy=galaxy, radius_mosaic=radius_mosaic,
                                                  survey=survey, pixscale=pixscale,
-                                                 nproc=nproc, force=force)
+                                                 nproc=nproc, force=force, cleanup=True)
         _done(galaxy, err, t0)
     else:
         with open(logfile, 'w') as log:
@@ -133,7 +133,7 @@ def _call_pipeline_coadds(onegal, galaxy, radius_mosaic, survey, pixscale,
                 _start(galaxy, log=log)
                 err = legacyhalos.coadds.pipeline_coadds(onegal, galaxy=galaxy, radius_mosaic=radius_mosaic,
                                                          survey=survey, pixscale=pixscale,
-                                                         nproc=nproc, force=force, log=log)
+                                                         nproc=nproc, force=force, log=log, cleanup=True)
                 _done(galaxy, err, t0, log=log)
 
 def _call_custom_coadds(onegal, galaxy, radius_mosaic, survey, pixscale,

--- a/bin/legacyhalos-mpi
+++ b/bin/legacyhalos-mpi
@@ -128,7 +128,7 @@ def _call_pipeline_coadds(onegal, galaxy, radius_mosaic, survey, pixscale,
                                                  nproc=nproc, force=force, cleanup=True)
         _done(galaxy, err, t0)
     else:
-        with open(logfile, 'w') as log:
+        with open(logfile, 'a') as log:
             with redirect_stdout(log), redirect_stderr(log):
                 _start(galaxy, log=log)
                 err = legacyhalos.coadds.pipeline_coadds(onegal, galaxy=galaxy, radius_mosaic=radius_mosaic,
@@ -146,7 +146,7 @@ def _call_custom_coadds(onegal, galaxy, radius_mosaic, survey, pixscale,
                                                survey=survey, pixscale=pixscale, nproc=nproc)
         _done(galaxy, err, t0)
     else:
-        with open(logfile, 'w') as log:
+        with open(logfile, 'a') as log:
             with redirect_stdout(log), redirect_stderr(log):
                 _start(galaxy, log=log)
                 err = legacyhalos.coadds.custom_coadds(onegal, galaxy=galaxy, radius_mosaic=radius_mosaic,
@@ -174,7 +174,7 @@ def _call_ellipse(onegal, galaxy, pixscale, verbose, debug, logfile, hsc):
                                                       noellipsefit=True, hsc=hsc)
         _done(galaxy, err, t0)
     else:
-        with open(logfile, 'w') as log:
+        with open(logfile, 'a') as log:
             with redirect_stdout(log), redirect_stderr(log):
                 _start(galaxy, log=log)
                 err = legacyhalos.ellipse.legacyhalos_ellipse(onegal, pixscale=pixscale,
@@ -196,7 +196,7 @@ def _call_sersic(onegal, galaxy, galaxydir, seed, verbose, debug, logfile, hsc):
                                                     debug=debug, verbose=verbose, seed=seed)
         _done(galaxy, err, t0)
     else:
-        with open(logfile, 'w') as log:
+        with open(logfile, 'a') as log:
             with redirect_stdout(log), redirect_stderr(log):
                 _start(galaxy, log=log, seed=seed)
                 err = legacyhalos.sersic.legacyhalos_sersic(onegal, galaxy=galaxy, galaxydir=galaxydir,
@@ -218,7 +218,7 @@ def _call_sky(onegal, galaxy, galaxydir, survey, seed, nproc, pixscale,
                                               debug=debug, verbose=verbose, force=force)
         _done(galaxy, err, t0)
     else:
-        with open(logfile, 'w') as log:
+        with open(logfile, 'a') as log:
             with redirect_stdout(log), redirect_stderr(log):
                 _start(galaxy, log=log, seed=seed)
                 err = legacyhalos.sky.legacyhalos_sky(onegal, survey=survey, galaxy=galaxy, galaxydir=galaxydir,
@@ -247,7 +247,7 @@ def _call_htmlplots(onegal, galaxy, survey, pixscale, nproc, debug, clobber,
                                               ccdqa=ccdqa, maketrends=maketrends)
         _done(galaxy, err, t0)
     else:
-        with open(logfile, 'w') as log:
+        with open(logfile, 'a') as log:
             with redirect_stdout(log), redirect_stderr(log):
                 _start(galaxy, log=log)
                 if hsc:

--- a/bin/legacyhalos-mpi
+++ b/bin/legacyhalos-mpi
@@ -22,6 +22,8 @@ import legacyhalos.coadds
 import legacyhalos.html
 import legacyhalos.integrate
 
+from legacyhalos.misc import RADIUS_CLUSTER_KPC
+
 def get_survey_dir(onegal):
     if onegal['RELEASE'] == 6000:
         return '/global/project/projectdirs/cosmo/work/legacysurvey/dr6'
@@ -413,7 +415,8 @@ def main():
         
         # Need the cluster "radius" to build the coadds.
         if args.coadds or args.custom_coadds or args.sky or args.htmlplots:
-            radius_mosaic_arcsec = legacyhalos.misc.cutout_radius_kpc(redshift=onegal['Z']) # [arcsec]
+            radius_mosaic_arcsec = legacyhalos.misc.cutout_radius_kpc(
+                redshift=onegal['Z'], radius_kpc=RADIUS_CLUSTER_KPC) # [arcsec]
 
             survey = LegacySurveyData()
             survey.survey_dir = get_survey_dir(onegal)

--- a/bin/legacyhalos-mpi
+++ b/bin/legacyhalos-mpi
@@ -156,7 +156,7 @@ def _call_custom_coadds(onegal, galaxy, radius_mosaic, survey, pixscale,
                                                        nproc=nproc, log=log)
                 _done(galaxy, err, t0, log=log)
                 
-def _call_ellipse(onegal, galaxy, pixscale, verbose, debug, logfile, hsc):
+def _call_ellipse(onegal, galaxy, pixscale, nproc, verbose, debug, logfile, hsc):
     """Wrapper script to do ellipse-fitting.
 
     """
@@ -170,7 +170,7 @@ def _call_ellipse(onegal, galaxy, pixscale, verbose, debug, logfile, hsc):
     t0 = time.time()
     if debug:
         _start(galaxy)
-        err = legacyhalos.ellipse.legacyhalos_ellipse(onegal, pixscale=pixscale,
+        err = legacyhalos.ellipse.legacyhalos_ellipse(onegal, pixscale=pixscale, nproc=nproc,
                                                       zcolumn=zcolumn,
                                                       verbose=verbose, debug=debug,
                                                       noellipsefit=True, hsc=hsc)
@@ -179,7 +179,7 @@ def _call_ellipse(onegal, galaxy, pixscale, verbose, debug, logfile, hsc):
         with open(logfile, 'a') as log:
             with redirect_stdout(log), redirect_stderr(log):
                 _start(galaxy, log=log)
-                err = legacyhalos.ellipse.legacyhalos_ellipse(onegal, pixscale=pixscale,
+                err = legacyhalos.ellipse.legacyhalos_ellipse(onegal, pixscale=pixscale, nproc=nproc,
                                                               zcolumn=zcolumn,
                                                               verbose=verbose, debug=debug,
                                                               noellipsefit=True, hsc=hsc)
@@ -457,7 +457,7 @@ def main():
                                 args.pixscale, args.nproc, args.debug, logfile)
                     
         if args.ellipse:
-            _call_ellipse(onegal, galaxy, args.pixscale, args.verbose,
+            _call_ellipse(onegal, galaxy, args.pixscale, args.nproc, args.verbose,
                           args.debug, logfile, args.hsc)
                         
         if args.sersic:

--- a/bin/legacyhalos-mpi
+++ b/bin/legacyhalos-mpi
@@ -423,7 +423,7 @@ def main():
             survey.output_dir = galaxydir
 
         if args.coadds:
-            print('After DR8 do not use mjd-min in coadds.py!')
+            print('After DR8 do not use mjd-min and update OUTLIERS in coadds.py!')
             _call_pipeline_coadds(onegal, galaxy, radius_mosaic_arcsec, survey, args.pixscale,
                                   args.nproc, args.force, args.debug, logfile)
                     

--- a/bin/legacyhalos-mpi
+++ b/bin/legacyhalos-mpi
@@ -229,11 +229,9 @@ def _call_sky(onegal, galaxy, galaxydir, survey, seed, nproc, pixscale,
                 _done(galaxy, err, t0, log=log)
                 
 def _call_htmlplots(onegal, galaxy, survey, pixscale, nproc, debug, clobber,
-                    verbose, logfile, hsc, htmldir):
+                    verbose, ccdqa, logfile, hsc, htmldir):
     """Wrapper script to build the pipeline coadds."""
     t0 = time.time()
-
-    ccdqa, maketrends = True, False
 
     if debug:
         _start(galaxy)
@@ -241,12 +239,12 @@ def _call_htmlplots(onegal, galaxy, survey, pixscale, nproc, debug, clobber,
             err = legacyhalos.html.make_plots(onegal, datadir=None, htmldir=htmldir,
                                               pixscale=pixscale, survey=survey, clobber=clobber,
                                               verbose=verbose, nproc=nproc,
-                                              ccdqa=ccdqa, maketrends=maketrends, hsc=True)
+                                              ccdqa=ccdqa, maketrends=False, hsc=True)
         else:
             err = legacyhalos.html.make_plots(onegal, datadir=None, htmldir=htmldir,
                                               pixscale=pixscale, survey=survey, clobber=clobber,
                                               verbose=verbose, nproc=nproc,
-                                              ccdqa=ccdqa, maketrends=maketrends)
+                                              ccdqa=ccdqa, maketrends=False)
         _done(galaxy, err, t0)
     else:
         with open(logfile, 'a') as log:
@@ -287,6 +285,7 @@ def main():
 
     parser.add_argument('--htmldir', type=str, help='Output directory for HTML files.')
     
+    parser.add_argument('--ccdqa', action='store_true', help='Build the CCD-level diagnostics.')
     parser.add_argument('--force', action='store_true', help='Use with --coadds; ignore previous pickle files.')
     parser.add_argument('--count', action='store_true', help='Count how many objects are left to analyze and then return.')
     parser.add_argument('--nomakeplots', action='store_true', help='Do not remake the QA plots for the HTML pages.')
@@ -470,8 +469,8 @@ def main():
 
         if args.htmlplots:
             _call_htmlplots(Table(onegal), galaxy, survey, args.pixscale, args.nproc,
-                            args.debug, args.clobber, args.verbose, logfile, args.hsc,
-                            args.htmldir)
+                            args.debug, args.clobber, args.verbose, args.ccdqa, logfile,
+                            args.hsc, args.htmldir)
 
     if rank == 0:
         print('Finished {} {} at {} after {:.3f} minutes'.format(

--- a/bin/legacyhalos-mpi.slurm
+++ b/bin/legacyhalos-mpi.slurm
@@ -10,14 +10,14 @@
 # #SBATCH -n 24
 # #SBATCH -t 04:00:00
 
-#SBATCH -o custom-coadd.log.%j
+#SBATCH -o ellipse.log.%j
 #SBATCH -p debug
-#SBATCH -N 1
-#SBATCH -n 4
+#SBATCH -N 6
+#SBATCH -n 48
 #SBATCH -t 00:30:00
 
 # for cori only
-# #SBATCH -C haswell
+#SBATCH -C haswell
 
 # sbatch ~/scratch/repos/legacyhalos/bin/legacyhalos-coadds.slurm
 
@@ -65,10 +65,10 @@ source $IMPY_DIR/bin/legacyhalos-env-nersc
 
 # custom coadds
 #time srun -N 16 -n 48 -c 8 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --custom-coadds --nproc 8 --mpi
-time srun -N 1 -n 4 -c 6 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --custom-coadds --nproc 6 --mpi
+#time srun -N 1 -n 4 -c 6 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --custom-coadds --nproc 6 --mpi
 
 # ellipse
-#time srun -N 1 -n 15 --cpu_bind=cores $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --ellipse --mpi 
+time srun -N 6 -n 48 -c 4 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --ellipse --nproc 4 --mpi 
 
 # html
 #time srun -N 2 -n 48 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --htmlplots --mpi --clobber

--- a/bin/legacyhalos-mpi.slurm
+++ b/bin/legacyhalos-mpi.slurm
@@ -12,12 +12,12 @@
 
 #SBATCH -o ellipse.log.%j
 #SBATCH -p debug
-#SBATCH -N 6
-#SBATCH -n 48
+#SBATCH -N 1
+#SBATCH -n 6
 #SBATCH -t 00:30:00
 
 # for cori only
-#SBATCH -C haswell
+# #SBATCH -C haswell
 
 # sbatch ~/scratch/repos/legacyhalos/bin/legacyhalos-coadds.slurm
 
@@ -68,7 +68,7 @@ source $IMPY_DIR/bin/legacyhalos-env-nersc
 #time srun -N 1 -n 4 -c 6 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --custom-coadds --nproc 6 --mpi
 
 # ellipse
-time srun -N 6 -n 48 -c 4 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --ellipse --nproc 4 --mpi 
+time srun -N 1 -n 6 -c 4 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --ellipse --nproc 4 --mpi 
 
 # html
 #time srun -N 2 -n 48 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --htmlplots --mpi --clobber

--- a/bin/legacyhalos-mpi.slurm
+++ b/bin/legacyhalos-mpi.slurm
@@ -2,7 +2,6 @@
 
 #SBATCH -A desi
 #SBATCH -L project
-#SBATCH -o legacyhalos.log.%j
 #SBATCH --mail-user=jmoustakas@siena.edu
 #SBATCH --mail-type=ALL
 
@@ -11,9 +10,10 @@
 # #SBATCH -n 24
 # #SBATCH -t 04:00:00
 
+#SBATCH -o custom-coadd.log.%j
 #SBATCH -p debug
-#SBATCH -N 2
-#SBATCH -n 48
+#SBATCH -N 1
+#SBATCH -n 4
 #SBATCH -t 00:30:00
 
 # for cori only
@@ -61,15 +61,16 @@ export IMPY_DIR=$HOME/repos/git/impy
 source $IMPY_DIR/bin/legacyhalos-env-nersc
 
 # pipeline coadds
-# time srun -N 8 -n 24 -c 8 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --coadds --nproc 8 --mpi
+#time srun -N 2 -n 6 -c 8 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --coadds --nproc 8 --mpi
 
 # custom coadds
-#time srun -N 2 -n 6 -c 8 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --custom-coadds --nproc 8 --mpi
+#time srun -N 16 -n 48 -c 8 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --custom-coadds --nproc 8 --mpi
+time srun -N 1 -n 4 -c 6 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --custom-coadds --nproc 6 --mpi
 
 # ellipse
 #time srun -N 1 -n 15 --cpu_bind=cores $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --ellipse --mpi 
 
 # html
-time srun -N 2 -n 48 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --htmlplots --mpi --clobber
+#time srun -N 2 -n 48 $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --htmlplots --mpi --clobber
 # time srun -N 1 -n 2 -c 6 --cpu_bind=cores $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --first 0 --last 99 --htmlplots --nproc 6 --mpi --clobber
 # time $LEGACYHALOS_CODE_DIR/bin/legacyhalos-mpi --htmlplots --nproc 1 --clobber

--- a/py/legacyhalos/coadds.py
+++ b/py/legacyhalos/coadds.py
@@ -506,16 +506,20 @@ def custom_coadds(onegal, galaxy=None, survey=None, radius_mosaic=None,
                 hdr = sky['{}-header'.format(key)]
                 ff.write(sky['{}-mask'.format(key)], extname=key, header=hdr)
 
-        ccdfile = os.path.join(survey.output_dir, '{}-ccddata-grz.fits.fz'.format(galaxy))
-        print('Writing {}'.format(ccdfile))
-        if os.path.isfile(ccdfile):
-            os.remove(ccdfile)
-        with fitsio.FITS(ccdfile, 'rw') as ff:
-            for ii, ccd in enumerate(survey.ccds):
-                im = survey.get_image_object(ccd)
-                key = '{}-{:02d}-{}'.format(im.name, im.hdu, im.band)
-                hdr = sky['{}-header'.format(key)]
-                ff.write(sky['{}-image'.format(key)].astype('f4'), extname=key, header=hdr)
+        # These are the actual images, which results in a giant file.  Keeping
+        # the code here for legacy purposes but I'm not sure we should ever
+        # write it out.
+        if False:
+            ccdfile = os.path.join(survey.output_dir, '{}-ccddata-grz.fits.fz'.format(galaxy))
+            print('Writing {}'.format(ccdfile))
+            if os.path.isfile(ccdfile):
+                os.remove(ccdfile)
+            with fitsio.FITS(ccdfile, 'rw') as ff:
+                for ii, ccd in enumerate(survey.ccds):
+                    im = survey.get_image_object(ccd)
+                    key = '{}-{:02d}-{}'.format(im.name, im.hdu, im.band)
+                    hdr = sky['{}-header'.format(key)]
+                    ff.write(sky['{}-image'.format(key)].astype('f4'), extname=key, header=hdr)
 
     # [3] Modify each tim by subtracting our new estimate of the sky.
     newtims = []

--- a/py/legacyhalos/coadds.py
+++ b/py/legacyhalos/coadds.py
@@ -442,21 +442,24 @@ def custom_coadds(onegal, galaxy=None, survey=None, radius_mosaic=None,
 
     # Read the outliers masks and apply them -- temporary hack until we address
     # legacypipe/#271
+    print('Fix me after #271')
     outliersfile = os.path.join(survey.output_dir, '{}-outliers.fits.fz'.format(galaxy))
     if not os.path.isfile(outliersfile):
         print('Missing outliers masks {}'.format(outliersfile))
         return 0
-    outliers = fitsio.FITS(outliersfile)
-
-    for tim in tims:
-        key = '{}-{:02d}-{}'.format(tim.imobj.name, tim.imobj.hdu, tim.imobj.band)
-        try:
-            #print('Masking from {}'.format(key))
-            mask, hdr = outliers[key].read(), outliers[key].read_header()
-            tim.dq |= (mask > 0) * CP_DQ_BITS['outlier']
-            tim.getInvError()[mask > 0] = 0.0
-        except:
-            pass
+    try:
+        outliers = fitsio.FITS(outliersfile)
+        for tim in tims:
+            key = '{}-{:02d}-{}'.format(tim.imobj.name, tim.imobj.hdu, tim.imobj.band)
+            try:
+                #print('Masking from {}'.format(key))
+                mask, hdr = outliers[key].read(), outliers[key].read_header()
+                tim.dq |= (mask > 0) * CP_DQ_BITS['outlier']
+                tim.getInvError()[mask > 0] = 0.0
+            except:
+                pass
+    except:
+        pass
 
     # [2] Derive the custom mask and sky background for each (full) CCD and
     # write out a MEF -custom-mask.fits.gz file.

--- a/py/legacyhalos/ellipse.py
+++ b/py/legacyhalos/ellipse.py
@@ -270,10 +270,18 @@ def ellipsefit_multiband(galaxy, galaxydir, data, sample, maxsma=None, nproc=1,
     ellipse0 = Ellipse(img, geometry=geometry0)
 
     smamin, smamax = 0.05*majoraxis, 1.2*majoraxis # inner, outer radius
-    sma0 = smamin*1.1
-    iso0 = ellipse0.fit_image(sma0, minsma=smamin, maxsma=smamax,
-                              integrmode=integrmode, sclip=sclip, nclip=nclip,
-                              step=0.5, linear=False) # note smaller step size
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        factor = (1.1, 1.2, 1.3, 1.4)
+        for ii, fac in enumerate(factor): # try a few different starting sma0
+            sma0 = smamin*fac
+            iso0 = ellipse0.fit_image(sma0, minsma=smamin, maxsma=smamax,
+                                      integrmode=integrmode, sclip=sclip, nclip=nclip,
+                                      step=0.5, linear=False) # note smaller step size
+            if len(iso0) > 0:
+                break
+
+    pdb.set_trace()
     if len(iso0) == 0:
         print('Initial ellipse-fitting failed!')
         return ellipsefit

--- a/py/legacyhalos/html.py
+++ b/py/legacyhalos/html.py
@@ -305,7 +305,7 @@ def _javastring():
 def make_html(sample=None, datadir=None, htmldir=None, band=('g', 'r', 'z'),
               refband='r', pixscale=0.262, zcolumn='Z', first=None, last=None,
               nproc=1, survey=None, makeplots=True, clobber=False, verbose=True,
-              maketrends=False, ccdqa=True):
+              maketrends=False, ccdqa=False):
     """Make the HTML pages.
 
     """

--- a/py/legacyhalos/html.py
+++ b/py/legacyhalos/html.py
@@ -13,8 +13,8 @@ import legacyhalos.io
 import legacyhalos.misc
 import legacyhalos.hsc
 
-from legacyhalos.misc import plot_style
-sns = plot_style()
+from legacyhalos.misc import RADIUS_CLUSTER_KPC
+sns, _ = legacyhalos.misc.plot_style()
 
 #import seaborn as sns
 #sns.set(style='ticks', font_scale=1.4, palette='Set2')
@@ -33,7 +33,8 @@ def qa_ccd(onegal, galaxy, galaxydir, htmlgalaxydir, pixscale=0.262,
         survey = LegacySurveyData()
 
     radius_pixel = legacyhalos.misc.cutout_radius_kpc(
-        redshift=onegal[zcolumn], pixscale=pixscale) # [pixels]
+        redshift=onegal[zcolumn], pixscale=pixscale,
+        radius_kpc=RADIUS_CLUSTER_KPC) # [pixels]
 
     qarootfile = os.path.join(htmlgalaxydir, '{}-2d'.format(galaxy))
     #maskfile = os.path.join(galaxydir, '{}-custom-ccdmasks.fits.fz'.format(galaxy))
@@ -311,9 +312,6 @@ def make_html(sample=None, datadir=None, htmldir=None, band=('g', 'r', 'z'),
     import subprocess
     import fitsio
 
-    import legacyhalos.io
-    from legacyhalos.misc import cutout_radius_kpc
-
     if datadir is None:
         datadir = legacyhalos.io.legacyhalos_data_dir()
     if htmldir is None:
@@ -333,7 +331,9 @@ def make_html(sample=None, datadir=None, htmldir=None, band=('g', 'r', 'z'),
     # Get the viewer link
     def _viewer_link(gal):
         baseurl = 'http://legacysurvey.org/viewer/'
-        width = 2 * cutout_radius_kpc(redshift=gal[zcolumn], pixscale=0.262) # [pixels]
+        width = 2 * legacyhalos.misc.cutout_radius_kpc(
+            redshift=gal[zcolumn], pixscale=0.262,
+            radius_kpc=RADIUS_CLUSTER_KPC) # [pixels]
         if width > 400:
             zoom = 14
         else:

--- a/py/legacyhalos/lsbs.py
+++ b/py/legacyhalos/lsbs.py
@@ -91,12 +91,21 @@ def read_sample(verbose=False):
     """
     # Really should be reading this from disk.
     sample = Table()
-    sample['GALAXY'] = np.array(['NGC1052-F2'])
-    sample['RA'] = np.array([40.4455]).astype('f8')
-    sample['DEC'] = np.array([-8.4031]).astype('f8')
-    sample['RADIUS_MOSAIC'] = np.array([20.0 * 60]).astype('f4') # mosaic half-width and half-height [arcsec]
-    sample['RADIUS_GALAXY'] = np.array([20.0]).astype('f4')      # galaxy radius [arcsec]
+    sample['GALAXY'] = np.array(['M87'])
+    sample['RA'] = np.array([187.705930]).astype('f8')
+    sample['DEC'] = np.array([12.391123]).astype('f8')
+    sample['RADIUS_MOSAIC'] = np.array([10.0 * 60]).astype('f4') # mosaic half-width and half-height [arcsec]
+    sample['RADIUS_GALAXY'] = np.array([4.0 * 60]).astype('f4')  # galaxy radius [arcsec]
     sample['RELEASE'] = np.array([7000]).astype(int)
+
+    if False:
+        sample = Table()
+        sample['GALAXY'] = np.array(['NGC1052-F2'])
+        sample['RA'] = np.array([40.4455]).astype('f8')
+        sample['DEC'] = np.array([-8.4031]).astype('f8')
+        sample['RADIUS_MOSAIC'] = np.array([20.0 * 60]).astype('f4') # mosaic half-width and half-height [arcsec]
+        sample['RADIUS_GALAXY'] = np.array([20.0]).astype('f4')      # galaxy radius [arcsec]
+        sample['RELEASE'] = np.array([7000]).astype(int)
 
     return sample
 

--- a/py/legacyhalos/mge.py
+++ b/py/legacyhalos/mge.py
@@ -142,6 +142,7 @@ MODIFICATION HISTORY:
 from __future__ import print_function
 
 import numpy as np
+import numpy.ma as ma
 import matplotlib.pyplot as plt
 from matplotlib import patches
 from scipy import signal, ndimage
@@ -165,7 +166,12 @@ class find_galaxy(object):
         if level is None:
             level = np.percentile(a, (1 - fraction)*100)
 
-        mask = a > level
+        if type(img) is ma.MaskedArray:
+            mask = ma.getmask(img)
+        else:
+            mask = np.zeros_like(img).astype(bool)
+
+        mask = np.logical_or(mask, a > level)
         labels, nb = ndimage.label(mask)   # Get blob indices
         sizes = ndimage.sum(mask, labels, np.arange(nb + 1))
         j = np.argsort(sizes)[-nblob]      # find the nblob-th largest blob

--- a/py/legacyhalos/misc.py
+++ b/py/legacyhalos/misc.py
@@ -12,6 +12,8 @@ import numpy as np
 
 from astrometry.util.util import Tan
 
+RADIUS_CLUSTER_KPC = 250.0 # default cluster radius
+
 def srcs2image(srcs, wcs, psf_sigma=1.0):
     """Build a model image from a Tractor catalog.
 
@@ -151,7 +153,7 @@ def destroy_logger(log):
         hndl.flush()
         hndl.close()
 
-def cutout_radius_kpc(redshift, pixscale=None, radius_kpc=150):
+def cutout_radius_kpc(redshift, pixscale=None, radius_kpc=250):
     """Get a cutout radius of RADIUS_KPC [in pixels] at the redshift of the cluster.
 
     """

--- a/py/legacyhalos/misc.py
+++ b/py/legacyhalos/misc.py
@@ -153,7 +153,7 @@ def destroy_logger(log):
         hndl.flush()
         hndl.close()
 
-def cutout_radius_kpc(redshift, pixscale=None, radius_kpc=250):
+def cutout_radius_kpc(redshift, pixscale=None, radius_kpc=RADIUS_CLUSTER_KPC):
     """Get a cutout radius of RADIUS_KPC [in pixels] at the redshift of the cluster.
 
     """

--- a/py/legacyhalos/qa.py
+++ b/py/legacyhalos/qa.py
@@ -19,6 +19,8 @@ import matplotlib.patches as patches
 import legacyhalos.io
 import legacyhalos.misc
 
+from legacyhalos.misc import RADIUS_CLUSTER_KPC
+
 sns, _ = legacyhalos.misc.plot_style()
 #snscolors = sns.color_palette()
 
@@ -1258,7 +1260,8 @@ def display_ccdpos(onegal, ccds, radius=None, pixscale=0.262, zcolumn='Z',
     """
     if radius is None:
         radius = legacyhalos.misc.cutout_radius_kpc(
-            redshift=onegal[zcolumn], pixscale=pixscale) # [pixels]
+            redshift=onegal[zcolumn], pixscale=pixscale,
+            radius_kpc=RADIUS_CLUSTER_KPC) # [pixels]
 
     wcs = legacyhalos.misc.simple_wcs(onegal, radius=radius, pixscale=pixscale, zcolumn=zcolumn)
     width, height = wcs.get_width() * pixscale / 3600, wcs.get_height() * pixscale / 3600 # [degrees]

--- a/py/legacyhalos/sandbox/ellipse-geometry-algorithms.py
+++ b/py/legacyhalos/sandbox/ellipse-geometry-algorithms.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""Testing out various shape measurements.
+
+from legacyhalos.io import read_multiband
+import numpy.ma as ma
+dd = read_multiband('41113651750406589', '8/410/41113651750406589/')
+fitsio.write('image.fits', ma.filled(dd['z_masked'], fill_value=0), clobber=True)
+
+from legacyhalos.mge import find_galaxy
+import numpy as np
+gg = find_galaxy(img, nblob=1, binning=3, quiet=False)
+print(gg.xpeak, gg.ypeak, gg.eps, gg.majoraxis, np.radians(gg.pa-90))
+"""
+
+import fitsio, pdb
+import numpy as np
+import numpy.ma as ma
+from photutils import data_properties
+from photutils.isophote import EllipseGeometry, Ellipse
+from photutils import EllipticalAperture
+
+import matplotlib.pyplot as plt
+
+from astropy.visualization import AsinhStretch as Stretch
+from astropy.visualization import ImageNormalize
+from astropy.visualization import ZScaleInterval as Interval
+
+from legacyhalos.mge import find_galaxy
+
+img = fitsio.read('image.fits')
+img = ma.masked_array(img, img==0)
+
+props = data_properties(img, mask=img==0)
+props2 = find_galaxy(img, nblob=1, fraction=0.05, binning=5, quiet=False, plot=True)
+
+geo = EllipseGeometry(x0=props2.xpeak, y0=props2.ypeak, sma=props2.majoraxis,
+                      eps=props2.eps, pa=np.radians(props2.pa-90))
+ell = Ellipse(img, geometry=geo)
+
+# Fit at least 10 isophotes between a semi-major axis of 1 and (75% times?) the
+# majoraxis and take the mean value.
+nsma = 10
+smamin, smamax = 0.05*props2.majoraxis, props2.majoraxis # /3
+step = np.int((smamax - smamin) / nsma)
+smagrid = np.linspace(smamin, smamax, nsma).astype(int)
+sma0 = (smamax-smamin)/2
+#sma0 = smamin * 5
+print(smamin, smamax, sma0, step, smagrid)
+
+print('Fitting image')
+iso = ell.fit_image(sma0, minsma=smamin, maxsma=smamax,
+                    integrmode='median', sclip=3, nclip=2,
+                    maxrit=None, step=0.5, linear=False,
+                    maxgerr=0.5)
+print(iso.sma)
+print(iso.stop_code)
+#print(iso.intens)
+
+good = np.where(iso.stop_code < 4)[0]
+nn = len(good)
+print('Starting values: x0={}, y0={}, eps={}, pa={}'.format(geo.x0, geo.y0, geo.eps, props2.pa))
+#print('Final values: x0={}, y0={}, eps={}, pa={}'.format(geo.x0, geo.y0, geo.eps, props2.pa))
+
+xx0 = iso.x0[good]
+yy0 = iso.y0[good]
+eeps = iso.eps[good]
+ppa = np.degrees(iso.pa[good])+90
+
+print('x0 = {}+/-{}'.format(np.mean(xx0), np.std(xx0)/np.sqrt(nn)))
+print('y0 = {}+/-{}'.format(np.mean(yy0), np.std(yy0)/np.sqrt(nn)))
+print('eps = {}+/-{}'.format(np.mean(eeps), np.std(eeps)/np.sqrt(nn)))
+print('pa = {}+/-{}'.format(np.mean(ppa), np.std(ppa)/np.sqrt(nn)))
+#print(iso.x0[good], iso.y0[good], iso.eps[good], iso.pa
+
+cmap = 'viridis'
+interval = Interval(contrast=0.9)
+norm = ImageNormalize(img, interval=interval, stretch=Stretch(a=0.95))
+
+im = plt.imshow(img, origin='lower', norm=norm, cmap=cmap, #cmap=cmap[filt],
+                interpolation='nearest')
+
+for ss in iso.sma[good]:
+    efit = iso.get_closest(ss)
+    x, y = efit.sampled_coordinates()
+    plt.plot(x, y, color='k', lw=1, alpha=0.75)
+
+EllipticalAperture((props.xcentroid.value, props.ycentroid.value),
+                   props.semimajor_axis_sigma.value,
+                   props.semiminor_axis_sigma.value,
+                   props.orientation.value).plot(color='blue', lw=1, alpha=0.75)
+EllipticalAperture((props2.xpeak, props2.ypeak), props2.majoraxis, 
+                   props2.majoraxis*(1-props2.eps), 
+                   np.radians(props2.pa-90)).plot(color='red', lw=1, alpha=0.75)
+
+plt.savefig('junk.png')
+
+#g = EllipseGeometry(x0=266, y0=266, eps=0.240, sma=110, pa=1.0558)
+#ell = Ellipse(img, geometry=g)
+#iso = ell.fit_image(3, integrmode='median', sclip=3, nclip=2, linear=False, step=0.1)
+
+pdb.set_trace()


### PR DESCRIPTION
Many little but important updates:
* Mosaic cut-outs increased from 300 to 500 kpc (in diameter); surface brightness profiles out to 150-250 kpc for some galaxies look totally awesome!
* Better initial elliptical geometry.  Previously we were using `MGE` to get the (fixed) ellipticity and position angle, but now we actually fit 5-10 isophotes in the high signal-to-noise region of the galaxy and take the median ellipticity and position angle.  The centers of the ellipses are also fixed to the nearest integer pixel.
* Lots of little speed-ups.  Ellipse-fitting and aperture photometry are now multi-processed (reducing the compute time by a factor of 5 or more).  Ellipse-fitting the reference r-band image is still a bottleneck, however (see https://github.com/astropy/photutils/issues/802).  
* Additional informative output logging.