### PR TITLE
algorithmically specify the ellipse columns when ellipse-fitting fails

### DIFF
--- a/bin/virgofilaments/virgofilaments-mpi
+++ b/bin/virgofilaments/virgofilaments-mpi
@@ -117,8 +117,8 @@ def main():
             #if len(groups) == 0:
             #    print('No complete galaxies!')
             #    return
-            build_catalog(sample, fullsample, nproc=args.nproc, verbose=args.verbose,
-                          refcat=refcat, clobber=args.clobber)
+            build_catalog(sample, fullsample, bands=['g', 'r', 'z'], unwise=True, galex=True, 
+                          nproc=args.nproc, verbose=args.verbose, refcat=refcat, clobber=args.clobber)
     
             #build_catalog(sample[groups[0]], nproc=args.nproc, verbose=args.verbose, refcat=refcat,
             #              clobber=args.clobber)

--- a/py/legacyhalos/io.py
+++ b/py/legacyhalos/io.py
@@ -140,8 +140,8 @@ def get_run(onegal, racolumn='RA', deccolumn='DEC'):
     return run
 
 # ellipsefit data model
-def _get_ellipse_datamodel(sbthresh, apertures, bands=['g', 'r', 'z'], add_datamodel_cols=None,
-                           copy_mw_transmission=False):
+def _get_ellipse_datamodel(sbthresh, apertures, bands=['g', 'r', 'z'],
+                           add_datamodel_cols=None, copy_mw_transmission=False):
     cols = [
         ('bands', None),
         ('refband', None),


### PR DESCRIPTION
When ellipse-fitting is not possible (e.g., GALEX imaging is missing) or fails (e.g., the central region of the target galaxy is fully masked) we populate "empty" set of values for the data model. Here, this is done algorithmically so that other, project-specific codes (e.g., virgofilaments) can determine which columns are "supposed" to be multidimensional. 
